### PR TITLE
bug fix pq-localize-ja.js

### DIFF
--- a/localize/pq-localize-ja.js
+++ b/localize/pq-localize-ja.js
@@ -18,7 +18,7 @@ $.paramquery.pqPager.regional['ja']={
     strFirstPage:"最初",
     strLastPage:"最後",
     strNextPage:"次",
-    strPage:"{0}　/ {1}  ページ",
+    strPage:"{0}  / {1}  ページ",
     strPrevPage:"前",
     strRefresh:"リフレッシュ",
     strRpp:"１ページあたりのレコード: {0}",


### PR DESCRIPTION
The page number is not displayed in Japanese.
Please Refer to https://paramquery.com/demos/localize and select locale Japanese.